### PR TITLE
PTSE-53 - Add extra data to properties in external APIs (only zooking yet)

### DIFF
--- a/apis/api_zooking/v1/properties.py
+++ b/apis/api_zooking/v1/properties.py
@@ -1,50 +1,292 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from typing import List
 from base_schemas.property import PropertyBase, PropertyInDB
+from .zooking_schemas import (
+    ZookingPropertyInDB,
+    ZookingBedroom,
+    ZookingBedType,
+    ZookingBathroom,
+    ZookingBathroomFixtures,
+    ZookingAmenity,
+    ZookingPropertyBase
+)
 from threading import Lock
 
 data = {
-    1: PropertyInDB(id=1, user_email="joedoe@gmail.com", name="Girassol", address="Rua 1234", curr_price=140.00),
-    2: PropertyInDB(id=2, user_email="alicez@gmail.com", name="Poente Azul", address="Rua 5678", curr_price=24.00),
-    3: PropertyInDB(id=3, user_email="alicez@gmail.com", name="Conforto e Bem Estar", address="Rua 91011", curr_price=36.00),
-    4: PropertyInDB(id=4, user_email="alicez@gmail.com", name="Flores e Amores", address="Rua 121314", curr_price=24.00),
-    5: PropertyInDB(id=5, user_email="alicez@gmail.com",name="São José Residences", address="Rua 151617", curr_price=54.00),
-    6: PropertyInDB(id=6, user_email="alicez@gmail.com", name="Residencial Aveiro", address="Rua 181920", curr_price=133.00),
-    7: PropertyInDB(id=7, user_email="joedoe@gmail.com", name="Ponto8", address="Rua 212223", curr_price=32.00),
-    8: PropertyInDB(id=8, user_email="joedoe@gmail.com", name="Bom Lugar", address="Rua 242526", curr_price=130.00),
-    9: PropertyInDB(id=9, user_email="joedoe@gmail.com", name="Hotel Miradouro", address="Rua 272829", curr_price=30.00),
-    10: PropertyInDB(id=10 ,user_email="joedoe@gmail.com", name="Spot Hostel", address="Rua 303132", curr_price=90.00)
+    1: ZookingPropertyInDB(
+        id=1,
+        user_email="joedoe@gmail.com",
+        name="Girassol",
+        address="Rua 1234",
+        curr_price=140.00,
+        description="Tem muito sol",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[
+            ZookingBedroom(number_beds=2, bed_type=ZookingBedType.SINGLE_BED),
+            ZookingBedroom(number_beds=1, bed_type=ZookingBedType.QUEEN_BED),
+        ],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[ZookingBathroomFixtures.TOILET],
+            ),
+            ZookingBathroom(
+                name="bathroom_topfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.SHOWER,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
+    2: ZookingPropertyInDB(
+        id=2,
+        user_email="alicez@gmail.com",
+        name="Poente Azul",
+        address="Rua 5678",
+        curr_price=24.00,
+        description="A casa mais azul desde 1999",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[ZookingBedroom(number_beds=2, bed_type=ZookingBedType.KING_BED)],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.TUB,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
+    3: ZookingPropertyInDB(
+        id=3,
+        user_email="alicez@gmail.com",
+        name="Conforto e Bem Estar",
+        address="Rua 91011",
+        curr_price=36.00,
+        description="A residencia mais confortável",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[
+            ZookingBedroom(number_beds=1, bed_type=ZookingBedType.SINGLE_BED),
+            ZookingBedroom(number_beds=1, bed_type=ZookingBedType.SINGLE_BED),
+            ZookingBedroom(number_beds=1, bed_type=ZookingBedType.SINGLE_BED),
+            ZookingBedroom(number_beds=1, bed_type=ZookingBedType.SINGLE_BED),
+        ],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.TUB,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
+    4: ZookingPropertyInDB(
+        id=4,
+        user_email="alicez@gmail.com",
+        name="Flores e Amores",
+        address="Rua 121314",
+        curr_price=24.00,
+        description="Tem um jardim fixe",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[ZookingBedroom(number_beds=2, bed_type=ZookingBedType.KING_BED)],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.TUB,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
+    5: ZookingPropertyInDB(
+        id=5,
+        user_email="alicez@gmail.com",
+        name="São José Residences",
+        address="Rua 151617",
+        curr_price=54.00,
+        description="Yes",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[ZookingBedroom(number_beds=4, bed_type=ZookingBedType.SINGLE_BED)],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.TUB,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
+    6: ZookingPropertyInDB(
+        id=6,
+        user_email="alicez@gmail.com",
+        name="Residencial Aveiro",
+        address="Rua 181920",
+        curr_price=133.00,
+        description="Nao é em braga",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[
+            ZookingBedroom(number_beds=1, bed_type=ZookingBedType.SINGLE_BED),
+            ZookingBedroom(number_beds=1, bed_type=ZookingBedType.SINGLE_BED),
+            ZookingBedroom(number_beds=1, bed_type=ZookingBedType.SINGLE_BED),
+            ZookingBedroom(number_beds=1, bed_type=ZookingBedType.SINGLE_BED),
+        ],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.TUB,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
+    7: ZookingPropertyInDB(
+        id=7,
+        user_email="joedoe@gmail.com",
+        name="Ponto8",
+        address="Rua 212223",
+        curr_price=32.00,
+        description=".8",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[ZookingBedroom(number_beds=2, bed_type=ZookingBedType.KING_BED)],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.TUB,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
+    8: ZookingPropertyInDB(
+        id=8,
+        user_email="joedoe@gmail.com",
+        name="Bom Lugar",
+        address="Rua 242526",
+        curr_price=130.00,
+        description="O nome desta casa nao é mentira",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[ZookingBedroom(number_beds=4, bed_type=ZookingBedType.SINGLE_BED)],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.TUB,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
+    9: ZookingPropertyInDB(
+        id=9,
+        user_email="joedoe@gmail.com",
+        name="Hotel Miradouro",
+        address="Rua 272829",
+        curr_price=30.00,
+        description="Tem uma boa view",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[ZookingBedroom(number_beds=4, bed_type=ZookingBedType.SINGLE_BED)],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.TUB,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
+    10: ZookingPropertyInDB(
+        id=10,
+        user_email="joedoe@gmail.com",
+        name="Spot Hostel",
+        address="Rua 303132",
+        curr_price=90.00,
+        description="Sim, vais dormir num quarto com 10 pessoas",
+        number_of_guests=4,
+        square_meters=2000,
+        bedrooms=[ZookingBedroom(number_beds=4, bed_type=ZookingBedType.SINGLE_BED)],
+        bathrooms=[
+            ZookingBathroom(
+                name="bathroom_groundfloor",
+                bathroom_fixtures=[
+                    ZookingBathroomFixtures.TOILET,
+                    ZookingBathroomFixtures.TUB,
+                ],
+            ),
+        ],
+        amenities=[ZookingAmenity.AC, ZookingAmenity.WIFI],
+        additional_info="Se cá aparecerem, recebem um rebuçado"
+    ),
 }
 
 lock = Lock()
 
-router = APIRouter(
-    prefix="/properties",
-    tags=["properties"]
-)
+router = APIRouter(prefix="/properties", tags=["properties"])
 
 
 @router.get("", status_code=200)
-def get_properties_by_user(email: str) -> List[PropertyInDB]:
+def get_properties_by_user(email: str) -> List[ZookingPropertyInDB]:
     return [property for property in data.values() if property.user_email == email]
 
 
 @router.get("/{property_id}", status_code=200)
-def get_property_by_id(property_id: int) -> PropertyInDB:
-    return data[property_id]  
+def get_property_by_id(property_id: int) -> ZookingPropertyInDB:
+    if not data.get(property_id):
+        raise HTTPException(status_code=404, detail="Property doesn't exist")
+    return data[property_id]
 
 
 @router.post("", status_code=201)
-def create_property(property_data: PropertyBase) -> PropertyInDB:
+def create_property(property_data: ZookingPropertyBase) -> ZookingPropertyInDB:
     with lock:
         last_id = list(data.keys())[-1]
         id = last_id + 1
-        property_in_db = PropertyInDB(
+        property_in_db = ZookingPropertyInDB(
             user_email=property_data.user_email,
             name=property_data.name,
             address=property_data.address,
             curr_price=property_data.curr_price,
-            id=id
+            description=property_data.description,
+            number_of_guests=property_data.number_of_guests,
+            square_meters=property_data.square_meters,
+            bedrooms=property_data.bedrooms,
+            bathrooms=property_data.bathrooms,
+            amenities=property_data.amenities,
+            additional_info=property_data.additional_info,
+            id=id,
         )
         data[id] = property_in_db
     saved_property = data[id]
@@ -52,20 +294,29 @@ def create_property(property_data: PropertyBase) -> PropertyInDB:
 
 
 @router.put("/{property_id}", status_code=200)
-def update_property(property_id: int, property_data: PropertyBase) -> PropertyInDB:
-    updated_property = PropertyInDB(
-        user_email=property_data.user_email,
-        name=property_data.name,
-        address=property_data.address,
-        curr_price=property_data.curr_price,
-        id=property_id
-    )
+def update_property(property_id: int, property_data: ZookingPropertyBase) -> ZookingPropertyInDB:
+    updated_property = ZookingPropertyInDB(
+            user_email=property_data.user_email,
+            name=property_data.name,
+            address=property_data.address,
+            curr_price=property_data.curr_price,
+            description=property_data.description,
+            number_of_guests=property_data.number_of_guests,
+            square_meters=property_data.square_meters,
+            bedrooms=property_data.bedrooms,
+            bathrooms=property_data.bathrooms,
+            amenities=property_data.amenities,
+            additional_info=property_data.additional_info,
+            id=property_id,
+        )
     data[property_id] = updated_property
     saved_property = data[property_id]
     return saved_property
 
 
 @router.delete("/{property_id}", status_code=200)
-def delete_property(property_id: int) -> List[PropertyInDB]:
+def delete_property(property_id: int) -> List[ZookingPropertyInDB]:
+    if not data.get(property_id):
+        raise HTTPException(status_code=404, detail="Property doesn't exist")
     del data[property_id]
     return data.values()

--- a/apis/api_zooking/v1/zooking_schemas.py
+++ b/apis/api_zooking/v1/zooking_schemas.py
@@ -1,0 +1,39 @@
+from enum import Enum
+from base_schemas.property import PropertyBase
+from pydantic import BaseModel
+
+
+class ZookingAmenity(str, Enum):
+    WIFI = "wifi"
+    OPEN_PARKING = "open_parking"
+    AC = "AC"
+
+class ZookingBedType(str, Enum):
+    QUEEN_BED = "queen_bed"
+    KING_BED = "king_bed"
+    SINGLE_BED = "single_bed"
+
+class ZookingBedroom(BaseModel):
+    number_beds: int
+    bed_type: ZookingBedType
+
+class ZookingBathroomFixtures(str, Enum):
+    TUB = "tub"
+    SHOWER = "shower"
+    TOILET = "toilet"
+
+class ZookingBathroom(BaseModel):
+    name: str
+    bathroom_fixtures: list[ZookingBathroomFixtures]
+
+class ZookingPropertyBase(PropertyBase):
+    description: str
+    number_of_guests: int
+    square_meters: int
+    bedrooms: list[ZookingBedroom]
+    bathrooms: list[ZookingBathroom]
+    amenities: list[ZookingAmenity]
+    additional_info: str
+
+class ZookingPropertyInDB(ZookingPropertyBase):
+    id: int


### PR DESCRIPTION
Added more data to properties in the zooking API and refactored the API to use this new data schema. 

Here's an example of a property:
```json
{
    "user_email": "joao.p.dourado1@gmail.com",
    "name": "Test home",
    "address": "Rua 1234",
    "curr_price": 140.0,
    "description": "Tem muita chuva, trust me",
    "number_of_guests": 4,
    "square_meters": 2000,
    "bedrooms": [
        {
            "number_beds": 2,
            "bed_type": "single_bed"
        },
        {
            "number_beds": 1,
            "bed_type": "queen_bed"
        }
    ],
    "bathrooms": [
        {
            "name": "bathroom_groundfloor",
            "bathroom_fixtures": [
                "toilet"
            ]
        },
        {
            "name": "bathroom_topfloor",
            "bathroom_fixtures": [
                "toilet",
                "shower"
            ]
        }
    ],
    "amenities": [
        "AC",
        "wifi",
        "open_parking"
    ],
    "additional_info": "Se cá aparecerem, pagam",
    "id": 1
}
```